### PR TITLE
get ip and host by network mask

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ eureka_client.init(eureka_server="your-eureka-server-peer1,your-eureka-server-pe
 
 *About the instance `IP` and `hostname`*:
 
-If you are using a `Amazon` data center, `py-eureka-client` will try to use `local-ipv4` and `local-hostname` get from Amazon metadata service. In other cases, `py-eureka-client` will use the fist non-loopback ip address and hostname from your net interface. 
+If you are using a `Amazon` data center, `py-eureka-client` will try to use `local-ipv4` and `local-hostname` get from Amazon metadata service. In other cases, `py-eureka-client` will use the first non-loopback ip address and hostname from your net interface. 
 
 You can also specify both these tow field or just one of them explicitly:
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,21 @@ eureka_client.init(eureka_server="your-eureka-server-peer1,your-eureka-server-pe
                 instance_port=9090)
 ```
 
+If you are running your application in a docker-container you might have more than one interfaces attached. In this case you can specify a network to be used to get the container's ip and host.    
+```python
+import py_eureka_client.__netint_utils
+
+eureka_client.init(eureka_server="your-eureka-server-peer1,your-eureka-server-peer2",
+                eureka_protocol="https",
+                eureka_basic_auth_user="keijack",
+                eureka_basic_auth_password="kjauthpass",
+                eureka_context="/eureka/v2",
+                app_name="python_module_1", 
+                instance_ip=__netint_utils.get_ip_and_host_by_network('192.168.1.0/16'),
+                instance_host="my-py-component.mydomian.com",
+                instance_port=9090)
+```
+
 ### Call Remote Service
 
 After `init` the eureka client, this is the most simplist way to do service:

--- a/py_eureka_client/__netint_utils.py
+++ b/py_eureka_client/__netint_utils.py
@@ -23,6 +23,7 @@ SOFTWARE.
 """
 import socket
 import netifaces
+import ipaddress
 from py_eureka_client.logger import get_logger
 
 _logger = get_logger("netint_utils")
@@ -41,6 +42,30 @@ def get_ip_by_host(host):
     except:
         _logger.warn("Error when getting ip by host", exc_info=True)
         return host
+
+def get_ip_and_host_by_network(network):
+    if network:
+        if_list = netifaces.interfaces()
+        ip = ""
+        host = ""
+        try:
+            for if_name in if_list:
+                ifaddr = netifaces.ifaddresses(if_name)
+                if 2 in ifaddr:
+                    _ip = ifaddr[2][0]["addr"]
+                    if ipaddress.ip_address(_ip) in ipaddress.ip_network(network):
+                        ip = _ip
+                        host = get_host_by_ip(ip)
+                        break
+        except:
+            _logger.warn("Error when getting ip by network", exc_info=True)
+
+        if ip:
+            return ip, host
+    else:
+        _logger.warn("No network defined")
+
+    return "", ""
 
 def get_ip_and_host():
     if_list = netifaces.interfaces()


### PR DESCRIPTION
When using docker you might have multiple network interfaces attached to the container. if this is the case choosing the first non-loopback interface to determine the ip and host is not enough. Therefore specifying a network mask to choose the desired interface is required.