### PR TITLE
New optional parameter instance_ip_network to force autodetect correct network

### DIFF
--- a/py_eureka_client/eureka_client.py
+++ b/py_eureka_client/eureka_client.py
@@ -823,7 +823,9 @@ class EurekaClient:
 
     * instance_host： The host of this instance. 
 
-    * instance_ip: The ip of this instance. If instatnce_host and instance_ip are not specified, will try to find the ip via connection to the eureka server.
+    * instance_ip: The ip of this instance. If instance_host and instance_ip are not specified, will try to find the ip via connection to the eureka server.
+
+    * instance_ip_network: The ip network of this instance. If instance_host and instance_ip are not specified, will try to find the ip from the avaiable network adapters that matches the specified network. For example 192.168.1.0/24.
 
     * instance_port: The port of this instance. 
 
@@ -1548,6 +1550,7 @@ def init(eureka_server: str = _DEFAULT_EUREKA_SERVER_URL,
          instance_id: str = "",
          instance_host: str = "",
          instance_ip: str = "",
+         instance_ip_network: str = "",
          instance_port: int = _DEFAULT_INSTNACE_PORT,
          instance_unsecure_port_enabled: bool = True,
          instance_secure_port: int = _DEFAULT_INSTNACE_SECURE_PORT,
@@ -1594,6 +1597,7 @@ def init(eureka_server: str = _DEFAULT_EUREKA_SERVER_URL,
                               instance_id=instance_id,
                               instance_host=instance_host,
                               instance_ip=instance_ip,
+                              instance_ip_network=instance_ip_network,
                               instance_port=instance_port,
                               instance_unsecure_port_enabled=instance_unsecure_port_enabled,
                               instance_secure_port=instance_secure_port,

--- a/py_eureka_client/eureka_client.py
+++ b/py_eureka_client/eureka_client.py
@@ -881,6 +881,7 @@ class EurekaClient:
                  instance_id: str = "",
                  instance_host: str = "",
                  instance_ip: str = "",
+                 instance_ip_network: str = "",
                  instance_port: int = _DEFAULT_INSTNACE_PORT,
                  instance_unsecure_port_enabled: bool = True,
                  instance_secure_port: int = _DEFAULT_INSTNACE_SECURE_PORT,
@@ -925,6 +926,7 @@ class EurekaClient:
         self.__heartbeat_timer = Timer(renewal_interval_in_secs, self.__heartbeat)
         self.__heartbeat_timer.daemon = True
         self.__instance_ip = instance_ip
+        self.__instance_ip_network = instance_ip_network
         self.__instance_host = instance_host
         self.__aws_metadata = {}
 
@@ -933,7 +935,7 @@ class EurekaClient:
             if data_center_name == "Amazon":
                 self.__aws_metadata = self.__load_ec2_metadata_dict()
             if self.__instance_host == "" and self.__instance_ip == "":
-                self.__instance_ip, self.__instance_host = self.__get_ip_host()
+                self.__instance_ip, self.__instance_host = self.__get_ip_host(instance_ip_network)
             elif self.__instance_host != "" and self.__instance_ip == "":
                 self.__instance_ip = netint.get_ip_by_host(self.__instance_host)
                 if not EurekaClient.__is_ip(self.__instance_ip):
@@ -1000,8 +1002,8 @@ class EurekaClient:
 
         self.__application_mth_lock = RLock()
 
-    def __get_ip_host(self):
-        ip, host = netint.get_ip_and_host()
+    def __get_ip_host(self, network):
+        ip, host = netint.get_ip_and_host(network)
         if self.__aws_metadata and "local-ipv4" in self.__aws_metadata and self.__aws_metadata["local-ipv4"]:
             ip = self.__aws_metadata["local-ipv4"]
         if self.__aws_metadata and "local-hostname" in self.__aws_metadata and self.__aws_metadata["local-hostname"]:


### PR DESCRIPTION
I had the situation, that my first non loopback device was a openvpn adapter. In this case, the auto guess function selects the wrong IP address. Maybe it is useful, to have the possibility to define a correct network IP range  for auto detection. For example, if all microservices receives the configuration via Spring Cloud Config, the correct (docker) network IP range can be via this parameter.

Of cause, it is already possible, to to this like you documented it in the README.md:
```python
import py_eureka_client.netint_utils as netint_utils

ip, host = netint_utils.get_ip_and_host("192.168.10.0/24")

# you can get the ip only
ip = netint_utils.get_first_non_loopback_ip("192.168.10.0/24")
host = "my-py-component.mydomian.com"

eureka_client.init(eureka_server="your-eureka-server-peer1,your-eureka-server-peer2",
                eureka_protocol="https",
                eureka_basic_auth_user="keijack",
                eureka_basic_auth_password="kjauthpass",
                eureka_context="/eureka/v2",
                app_name="python_module_1", 
                instance_ip=ip,
                instance_host=host,
                instance_port=9090)
```

So this change is just a comfort improvement :)