### PR TITLE
fix http 406 error due to missing header

### DIFF
--- a/py_eureka_client/http_client.py
+++ b/py_eureka_client/http_client.py
@@ -138,11 +138,12 @@ class HttpResponse:
 class HttpClient:
 
     async def urlopen(self, request: Union[str, HttpRequest] = None,
-                      data: bytes = None, timeout: float = None) -> HttpResponse:
+                      data: bytes = None, timeout: float = None,
+                      headers = {'Accept-Encoding':'gzip, deflate'}) -> HttpResponse:
         if isinstance(request, HttpRequest):
             req = request
         elif isinstance(request, str):
-            req = HttpRequest(request)
+            req = HttpRequest(request,headers=headers)
         else:
             raise URLError("Unvalid URL")
 


### PR DESCRIPTION
eureka return 406 at eureka/v2/apps if missing headers = {'Accept-Encoding':'gzip, deflate'}

tested against eureka 1.10.11